### PR TITLE
Fix parametor validation in confirm api

### DIFF
--- a/module/line-pay.js
+++ b/module/line-pay.js
@@ -142,7 +142,7 @@ class LinePay {
 
         // Check if required parameters are all set.
         required_params.map((param) => {
-            if (!options[param]){
+            if (!param in options){
                 throw new Error(`Required parameter ${param} is missing.`);
             }
         })


### PR DESCRIPTION
When obtaining regKey with Preapproved payment, confirm api may be called with amount == 0
However, a validation error occurred like: 
> Error: Required parameter amount is missing.

I fixed it 💃 